### PR TITLE
Do not pin ld to pack resources

### DIFF
--- a/Build/Makefile
+++ b/Build/Makefile
@@ -68,7 +68,7 @@ $(XDG_OBJ): $(XDG_SOURCES)
 	$(CC) -MMD -Wall -DHAVE_MMAP -c $(addprefix $(XDG_DIR),$(patsubst %.o,%.c,$@)) -o $@ $(INCLUDES) $(LDFLAGS)
 
 $(RESOURCES_OBJ): $(RESOURCES)
-	cd $(RESOURCES_DIR) && ld -r -b binary $(patsubst %.o,%.png,$@) -o ../../Build/$@
+	cd $(RESOURCES_DIR) && $(LD) -r -b binary $(patsubst %.o,%.png,$@) -o ../../Build/$@
 
 $(DIALOG_OBJ): $(DIALOG_SOURCES)
 	$(CC) -MMD -Wall -c $(addprefix $(DIALOG_DIR),$(patsubst %.o,%.c,$@)) -o $@ $(INCLUDES) $(LDFLAGS)


### PR DESCRIPTION
Took a while - error message for cross build of XPolyMonk.lv2 was (not helpful exactly...):

| xmidi_keyboard.c:(.text+0x2a30): undefined reference to `_binary_midikeyboard_png_start'
| collect2: error: ld returned 1 exit status

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>