### PR TITLE
Do not require static dependencies for dynamic build

### DIFF
--- a/Build/Makefile
+++ b/Build/Makefile
@@ -17,7 +17,7 @@
 	# include path for library headers
 	INCLUDES := -I. -I$(HEADER_DIR) -I$(WIDGET_HEADER_DIR) -I$(RESOURCES_DIR) -I$(DIALOG_HEADER_DIR) -I$(XDG_DIR)
 	# link flags to dynamic link cairo and X11 (default)
-	LDFLAGS += -fPIC `pkg-config --static --cflags --libs cairo x11` -lm
+	LDFLAGS += -fPIC `pkg-config --cflags --libs cairo x11` -lm
 	# set link flags to static link cairo and X11
 	# (you could ignore ld warnings, but the resulting binary is huge
 	# (6.4Mb for x11 and cairo) NOT RECOMMENDED!!


### PR DESCRIPTION
`pkg-config --static` pulls in static-only dependencies that are not required for making dynamic executables.